### PR TITLE
[Fix] Fix ambiguous between variable and class

### DIFF
--- a/Sources/AppFolder/BaseFolder.swift
+++ b/Sources/AppFolder/BaseFolder.swift
@@ -25,8 +25,8 @@ extension BaseFolder {
      
      Example:
      ```
-     let applicationSupport = AppFolder.Library.Application_Support
-     let caches = AppFolder.Library.Caches
+     let applicationSupport = AppFolder.Library.application_Support
+     let caches = AppFolder.Library.caches
      ```
      */
     public static var Library: Library {
@@ -74,7 +74,7 @@ extension BaseFolder {
  
  ````
  let documents = AppFolder.Documents
- let caches = AppFolder.Library.Caches
+ let caches = AppFolder.Library.caches
  let cachesURL = caches.url
  ````
  

--- a/Sources/AppFolder/Directory.swift
+++ b/Sources/AppFolder/Directory.swift
@@ -110,7 +110,7 @@ public final class Library : Directory {
      # Important #
       - Data that can be downloaded again or regenerated should be stored here. Examples of files you should put in the Caches directory include database cache files and downloadable content, such as that used by magazine, newspaper, and map applications.
      */
-    public var Caches: Caches {
+    public var caches: Caches {
         return appending(Caches.self)
     }
     
@@ -123,7 +123,7 @@ public final class Library : Directory {
      # Important #
      - The Application Support directory is a good place to store files that might be in your Documents directory but that shouldn't be seen by users. For example, a database that your app needs but that the user would never open manually.
      */
-    public var Application_Support: Application_Support {
+    public var application_Support: Application_Support {
         return appending(Application_Support.self)
     }
     

--- a/Tests/AppFolderTests/AppFolderTests.swift
+++ b/Tests/AppFolderTests/AppFolderTests.swift
@@ -31,7 +31,7 @@ class AppFolderTests: XCTestCase {
 extension Library.Application_Support {
     
     final class CoreData : Directory { }
-    var CoreData: CoreData {
+    var coreData: CoreData {
         return appending(CoreData.self)
     }
     
@@ -40,7 +40,7 @@ extension Library.Application_Support {
 extension Library.Caches {
     
     final class Images_Cache : Directory { }
-    var Images_Cache: Images_Cache {
+    var images_Cache: Images_Cache {
         return appending(Images_Cache.self)
     }
     
@@ -49,12 +49,12 @@ extension Library.Caches {
 func testUsageScenario() {
     describe("typical usage") {
         $0.it("adding a folder inside Application Support") {
-            let coreData = AppFolder.Library.Application_Support.CoreData
+            let coreData = AppFolder.Library.application_Support.coreData
             let path = coreData.url.path
             try expect(path) == NSHomeDirectory() + "/Library/Application Support/CoreData"
         }
         $0.it("adding a folder inside Caches") {
-            let images = AppFolder.Library.Caches.Images_Cache
+            let images = AppFolder.Library.caches.images_Cache
             let path = images.url.path
             try expect(path) == NSHomeDirectory() + "/Library/Caches/Images Cache"
         }

--- a/Tests/AppFolderTests/BaseFolderSpec.swift
+++ b/Tests/AppFolderTests/BaseFolderSpec.swift
@@ -35,12 +35,12 @@ func testBaseFolder() {
             try expect(documents).to.beOfType(Documents.self)
         }
         $0.it("has a caches folder") {
-            let caches = TestBaseFolder.Library.Caches
+            let caches = TestBaseFolder.Library.caches
             try expect(caches.baseURL) == TestBaseFolder.baseURL
             try expect(caches).to.beOfType(Library.Caches.self)
         }
         $0.it("has an application support folder") {
-            let support = TestBaseFolder.Library.Application_Support
+            let support = TestBaseFolder.Library.application_Support
             try expect(support.baseURL) == TestBaseFolder.baseURL
             try expect(support).to.beOfType(Library.Application_Support.self)
         }
@@ -71,10 +71,10 @@ func testBaseFolder() {
             try check(directory: AppFolder.Documents, for: .documentDirectory)
         }
         $0.it("caches directory is located at the right place") {
-            try check(directory: AppFolder.Library.Caches, for: .cachesDirectory)
+            try check(directory: AppFolder.Library.caches, for: .cachesDirectory)
         }
         $0.it("application support directory is located at the right place") {
-            try check(directory: AppFolder.Library.Application_Support, for: .applicationSupportDirectory)
+            try check(directory: AppFolder.Library.application_Support, for: .applicationSupportDirectory)
         }
         $0.it("library directory is located at the right place") {
             try check(directory: AppFolder.Library, for: .libraryDirectory)

--- a/Tests/AppFolderTests/DirectorySpec.swift
+++ b/Tests/AppFolderTests/DirectorySpec.swift
@@ -94,7 +94,7 @@ func testDirectory() {
             try expect(customDir.folderName) == "Custom"
         }
         $0.it("can be created from another directory") {
-            let customDir = AppFolder.Library.Application_Support.appending("Custom")
+            let customDir = AppFolder.Library.application_Support.appending("Custom")
             try expect(customDir).to.beOfType(CustomDirectory.self)
             try expect(customDir.subpath) == "Library/Application Support/Custom"
             try expect(customDir.folderName) == "Custom"
@@ -103,7 +103,7 @@ func testDirectory() {
     
     describe("dynamic directory") {
         $0.it("can be subclassed to create customizable directory") {
-            let user5 = AppFolder.Library.Application_Support.User(id: 5)
+            let user5 = AppFolder.Library.application_Support.User(id: 5)
             try expect(user5.folderName) == "User-5"
             try expect(user5.subpath) == "Library/Application Support/User-5"
             try expect(user5).to.beOfType(UserIDDirectory.self)
@@ -126,11 +126,11 @@ func testDirectory() {
             }
         #endif
         $0.it("has a caches directory") {
-            let caches = AppFolder.Library.Caches
+            let caches = AppFolder.Library.caches
             try expect(caches.subpath) == "Library/Caches"
         }
         $0.it("has an application support directory") {
-            let applicationSupport = AppFolder.Library.Application_Support
+            let applicationSupport = AppFolder.Library.application_Support
             try expect(applicationSupport.subpath) == "Library/Application Support"
         }
     }

--- a/Tests/AppFolderTests/Readme.swift
+++ b/Tests/AppFolderTests/Readme.swift
@@ -10,7 +10,7 @@ import Foundation
 import AppFolder
 
 func showcase() throws {
-    let cachesURL = AppFolder.Library.Caches.url
+    let cachesURL = AppFolder.Library.caches.url
     let userCacheURL = cachesURL.appendingPathComponent("user-cache.json")
     let userCacheData = try Data(contentsOf: userCacheURL)
     print(userCacheData)
@@ -20,7 +20,7 @@ extension Documents {
     
     final class Photos : Directory { }
     
-    var Photos: Photos {
+    var photos: Photos {
         return appending(Photos.self)
     }
     
@@ -42,7 +42,7 @@ extension Documents {
 extension Library.Caches {
     
     class Images: Directory { }
-    var Images: Images {
+    var images: Images {
         return appending(Images.self)
     }
     
@@ -52,7 +52,7 @@ extension Library.Application_Support {
     
     final class Files : Directory { }
     
-    var Files: Files {
+    var files: Files {
         return appending()
     }
     


### PR DESCRIPTION
When using Swift4.1 with Xcode 9.3, the complier would throw an error saying that there are ambiguous usages between the properties and the nested class.

So I change all properties's first letter to lowercase, and also pass the test case before I summit.